### PR TITLE
Make sure to download all changes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,7 @@ fn main() {
         "--comments",
         "--commit-message",
         "--files",
+        "--no-limit",
         "--format",
         "JSON",
     ];


### PR DESCRIPTION
By default gerrit limits the number of changes to 500 maximum. If a user
has more than 500 changes in the specified time range, then the changes
in the query are capped to 500, faking the actual stats. Therefore, to
get the real information, we need to tell gerrit to not limit the number
of changes in the query.